### PR TITLE
Add pair type

### DIFF
--- a/src/snk_cli/utils.py
+++ b/src/snk_cli/utils.py
@@ -97,6 +97,9 @@ def serialise(d):
     """
     if isinstance(d, Path) or isinstance(d, datetime):
         return str(d)
+    
+    if isinstance(d, tuple):
+        return list(d) 
 
     if isinstance(d, list):
         return [serialise(x) for x in d]
@@ -155,7 +158,7 @@ def parse_config_args(args: List[str], options: List[Option]):
 
 def get_default_type(v):
     default_type = type(v)
-    if default_type == list and len(v) > 0:
+    if default_type is list and len(v) > 0:
         return f"List[{type(v[0]).__name__}]"
     return str(default_type.__name__)
 

--- a/tests/data/workflow/snk.yaml
+++ b/tests/data/workflow/snk.yaml
@@ -9,6 +9,10 @@ cli:
     type: bool
   null_annotation:
     default: null
+  KeyValuePair:
+    default: ["key", "value"]
+    help: A key-value pair
+    type: pair 
   enum:
     choices: [a, b, c]
   test:

--- a/tests/test_cli/test_validate.py
+++ b/tests/test_cli/test_validate.py
@@ -73,6 +73,18 @@ import pytest
         {"example": {"type": "list[path]"}},
         {"example": [Path("1"), Path("2")]}
     ),
+    # pair type
+    (
+        {"example": ["1", "2"]},
+        {"example": {"type": "pair[int, int]"}},
+        {"example": [1, 2]}   
+    ),
+    # choices
+    (
+        {"example": "a"},
+        {"example": {"type": "str", "choices": ["a", "b"]}},
+        {"example": "a"}
+    ),
     # nested dictionary
     (
         {"example": {"nested": "1"}},

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -1,0 +1,142 @@
+# integration tests for the annotation types from the snk config, snakemake config, and the command line interface
+
+import pytest
+from .utils import dynamic_runner
+from snk_cli.config import SnkConfig
+
+
+@pytest.mark.parametrize("snakemake_config,annotations,cli_args,expected", [
+    # str
+    (
+        {"example": "1"},
+        {"example": {"type": "str"}},
+        ["--example", "1"],
+        "{'example': '1'}"
+    )])
+def test_str(snakemake_config, annotations, cli_args, expected):
+    snk_config = SnkConfig(cli=annotations)
+    runner = dynamic_runner(snakemake_config, snk_config)
+    res = runner.invoke(["run"] + cli_args)
+    assert res.exit_code == 0, res.stderr
+    assert expected in res.stdout, res.stderr
+    
+@pytest.mark.parametrize("snakemake_config,annotations,cli_args,expected", [
+    # int
+    (
+        {"example": "1"},
+        {"example": {"type": "int"}},
+        ["--example", "1"],
+        "{'example': 1}"
+    )])
+def test_int(snakemake_config, annotations, cli_args, expected):
+    snk_config = SnkConfig(cli=annotations)
+    runner = dynamic_runner(snakemake_config, snk_config)
+    res = runner.invoke(["run"] + cli_args)
+    assert res.exit_code == 0, res.stderr
+    assert expected in res.stdout, res.stderr
+
+@pytest.mark.parametrize("snakemake_config,annotations,cli_args,expected", [
+    # float
+    (
+        {"example": "1"},
+        {"example": {"type": "float"}},
+        ["--example", "1"],
+        "{'example': 1.0}"
+    )])
+def test_float(snakemake_config, annotations, cli_args, expected):
+    snk_config = SnkConfig(cli=annotations)
+    runner = dynamic_runner(snakemake_config, snk_config)
+    res = runner.invoke(["run"] + cli_args)
+    assert res.exit_code == 0, res.stderr
+    assert expected in res.stdout, res.stderr
+
+@pytest.mark.parametrize("snakemake_config,annotations,cli_args,expected", [
+    # bool
+    (
+        {"example": "1"},
+        {"example": {"type": "bool"}},
+        ["--example"],
+        "{'example': True}"
+    )])
+def test_bool(snakemake_config, annotations, cli_args, expected):
+    snk_config = SnkConfig(cli=annotations)
+    runner = dynamic_runner(snakemake_config, snk_config)
+    res = runner.invoke(["run"] + cli_args)
+    assert res.exit_code == 0, res.stderr
+    assert expected in res.stdout, res.stderr
+
+@pytest.mark.parametrize("snakemake_config,annotations,cli_args,expected", [
+    # path
+    (
+        {"example": "file"},
+        {"example": {"type": "path"}},
+        ["--example", "file"],
+        "{'example': 'file'}"
+    )])
+def test_path(snakemake_config, annotations, cli_args, expected):
+    snk_config = SnkConfig(cli=annotations)
+    runner = dynamic_runner(snakemake_config, snk_config)
+    res = runner.invoke(["run"] + cli_args)
+    assert res.exit_code == 0, res.stderr
+    assert expected in res.stdout, res.stderr
+
+@pytest.mark.parametrize("snakemake_config,annotations,cli_args,expected", [
+    # list
+    (
+        {"example": [1,2,3]},
+        {"example": {"type": "list"}},
+        ["--example", "1", "--example", "2", "--example", "3"],
+        "{'example': ['1', '2', '3']}"
+    )])
+def test_list(snakemake_config, annotations, cli_args, expected):
+    snk_config = SnkConfig(cli=annotations)
+    runner = dynamic_runner(snakemake_config, snk_config)
+    res = runner.invoke(["run"] + cli_args)
+    assert res.exit_code == 0, res.stderr
+    assert expected in res.stdout, res.stderr
+
+@pytest.mark.parametrize("snakemake_config,annotations,cli_args,expected", [
+    # pair
+    (
+        {"example": [1, 2]},
+        {"example": {"type": "pair"}},
+        ["--example", "1", "2"],
+        "{'example': ['1', '2']}"
+    ),
+    (
+        {"example": [1, 2]},
+        {"example": {"type": "pair[int, int]"}},
+        ["--example", "1", "2"],
+        "{'example': [1, 2]}"
+    ),
+    (
+        {"example": ["1", "2"]},
+        {"example": {"type": "pair[float, float]"}},
+        ["--example", "1", "2"],
+        "{'example': [1.0, 2.0]}"
+    ),
+    (
+        {"example": ["1", "2"]},
+        {"example": {"type": "pair[str, str]"}},
+        ["--example", "1", "2"],
+        "{'example': ['1', '2']}"
+    ),
+    (
+        {"example": ["1", "2"]},
+        {"example": {"type": "pair[str, int]"}},
+        ["--example", "1", "2"],
+        "{'example': ['1', 2]}"
+    ),
+    (
+        {"example": ["1", "2"]},
+        {"example": {"type": "pair[int, str]"}},
+        ["--example", "1", "2"],
+        "{'example': [1, '2']}"
+    )
+])
+def test_pair(snakemake_config, annotations, cli_args, expected):
+    snk_config = SnkConfig(cli=annotations)
+    runner = dynamic_runner(snakemake_config, snk_config)
+    res = runner.invoke(["run"] + cli_args)
+    assert res.exit_code == 0, res.stderr
+    assert expected in res.stdout, res.stderr


### PR DESCRIPTION
This adds key value pair type:

```
cli:
  example:
    type: pair[str, int]
    default: ["key", 1]
```
Under the hood it uses the Tuple type (see https://typer.tiangolo.com/tutorial/multiple-values/options-with-multiple-values/#cli-options-with-multiple-values)