### PR TITLE
Change pulp dependency to >=2.8

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,7 @@ dependencies = [
   "typer~=0.9",
   "shellingham >=1.3.0",
   "rich >=10.11.0",
-  "pulp<2.8",  # Pin pulp <2.8 for snakemake: https://github.com/snakemake/snakemake/issues/2607
+  "pulp >=2.8",
   "art~=5.9",
   "makefun~=1.15",
   "datrie>=0.8.2",


### PR DESCRIPTION
https://github.com/snakemake/snakemake/issues/2607 is resolved now, so can unpin pulp dependency. Currently can't use snakemake 9 with snk-cli because of this.