### PR TITLE
Add compatibility with Snakemake v9 and newer typer

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -17,15 +17,18 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.10", 3.11, 3.12, 3.13]
-        snakemake-version: ["==7.32.4", ">8,<9", ">9"]
+        python-version: ["3.10", "3.11", "3.12", "3.13"]
+        snakemake-version: ["==7.32.4", ">8,<9", ">=9,<10"]
         exclude:
           # Exclude incompatible combinations
           - python-version: "3.10"
             snakemake-version: ">8,<9"
           - python-version: "3.10"
-            snakemake-version: ">9"
-          
+            snakemake-version: ">=9,<10"
+        include:
+          - python-version: "3.14"
+            snakemake-version: ">=9.22,<10"
+
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,18 +21,20 @@ classifiers = [
   "Programming Language :: Python :: 3.10",
   "Programming Language :: Python :: 3.11",
   "Programming Language :: Python :: 3.12",
+  "Programming Language :: Python :: 3.13",
+  "Programming Language :: Python :: 3.14",
   "Programming Language :: Python :: Implementation :: CPython",
   "Programming Language :: Python :: Implementation :: PyPy",
 ]
 dependencies = [
-  "snakemake>=7",
+  "snakemake>=7; python_version < '3.14'",
+  "snakemake>=9.22; python_version >= '3.14'",
   "typer~=0.9",
   "shellingham >=1.3.0",
   "rich >=10.11.0",
   "pulp<2.8",  # Pin pulp <2.8 for snakemake: https://github.com/snakemake/snakemake/issues/2607
   "art~=5.9",
   "makefun~=1.15",
-  "datrie>=0.8.2",
 ]
 
 [project.urls]
@@ -49,8 +51,12 @@ snakemake = ["==7.32.4"]  # Compatible with Python 3.10–3.13
 python = ["3.10", "3.11", "3.12", "3.13"]
 
 [[tool.hatch.envs.snakemake.matrix]]
-snakemake = [">8,<9", ">9"]  # Compatible only with Python 3.11 and 3.13
+snakemake = [">8,<9", ">=9,<10"]
 python = ["3.11", "3.12", "3.13"]
+
+[[tool.hatch.envs.snakemake.matrix]]
+snakemake = [">=9.22,<10"]  # Python 3.14 support starts with Snakemake 9.22
+python = ["3.14"]
 
 [tool.hatch.envs.default]
 dependencies = [

--- a/src/snk_cli/conda.py
+++ b/src/snk_cli/conda.py
@@ -28,9 +28,14 @@ class PersistenceMock:
     container_img_path: Path = None
     aux_path: Path = None
 
+    def __post_init__(self):
+        for path in (self.conda_env_path, self.conda_env_archive_path):
+            if path:
+                Path(path).mkdir(parents=True, exist_ok=True)
+
 
 def get_frontend():
-    if check_command_available("mamba"):
+    if check_command_available("mamba") and not is_snakemake_version_9_or_above:
         conda_frontend = "mamba"
     else:
         conda_frontend = "conda"

--- a/src/snk_cli/conda.py
+++ b/src/snk_cli/conda.py
@@ -1,8 +1,9 @@
 # This file contains functions to create and manage conda environments for snakemake workflows
-# it needs to work with v7, v8, and v9 of snakemake
+# it needs to work with v 7, 8 and 9 of snakemake
+# 
 from pathlib import Path
 from packaging import version
-from types import SimpleNamespace
+from dataclasses import dataclass
 import inspect
 import os
 
@@ -10,65 +11,34 @@ from snk_cli.utils import check_command_available
 from snakemake.deployment.conda import Env
 import snakemake
 
-try:
-    snakemake_version_text = snakemake.__version__
-except AttributeError:
-    from snakemake.common import __version__ as snakemake_version_text
-
-snakemake_version = version.parse(snakemake_version_text)
+snakemake_version = version.parse(snakemake.__version__)
 is_snakemake_version_8_or_above = snakemake_version >= version.parse('8')
 is_snakemake_version_9_or_above = snakemake_version >= version.parse('9')
 
-
-def create_persistence_paths(conda_prefix):
+@dataclass
+class PersistenceMock:
     """
-    Minimal workflow.persistence replacement for Env path calculation.
+    Mock for workflow.persistence
     """
-    return SimpleNamespace(
-        conda_env_path=Path(conda_prefix).resolve() if conda_prefix else None,
-        _metadata_path=None,
-        _incomplete_path=None,
-        shadow_path=None,
-        conda_env_archive_path=os.path.join(Path(".snakemake"), "conda-archive"),
-        container_img_path=None,
-        aux_path=None,
-    )
-
-
-def _create_workflow_namespace(conda_prefix):
-    """
-    Full duck-typed workflow mock for v9+, where Workflow.__init__ requires
-    logger_manager — too complex to construct just for conda env management.
-    Provides only the attributes that snakemake.deployment.conda.Env accesses.
-    """
-    persistence = create_persistence_paths(conda_prefix)
-    return SimpleNamespace(
-        persistence=persistence,
-        deployment_settings=SimpleNamespace(apptainer_args=""),
-        runtime_paths=[persistence.conda_env_path] if persistence.conda_env_path else [],
-        sourcecache=SimpleNamespace(
-            exists=lambda *a, **kw: False,
-            open=lambda *a, **kw: None,
-        ),
-    )
-
-
-def set_workflow_persistence(workflow, persistence):
-    if hasattr(workflow, "_persistence"):
-        workflow._persistence = persistence
-    else:
-        workflow.persistence = persistence
+    conda_env_path: Path = None
+    _metadata_path: Path = None
+    _incomplete_path: Path = None
+    shadow_path: Path = None
+    conda_env_archive_path: Path = None
+    container_img_path: Path = None
+    aux_path: Path = None
 
 
 def get_frontend():
     if check_command_available("mamba"):
-        return "mamba"
-    return "conda"
-
+        conda_frontend = "mamba"
+    else:
+        conda_frontend = "conda"
+    return conda_frontend
 
 def create_workflow_v7(conda_prefix):
     from snakemake.workflow import Workflow
-
+    
     conda_frontend = get_frontend()
     workflow = Workflow(
         snakefile=Path(),
@@ -79,11 +49,20 @@ def create_workflow_v7(conda_prefix):
         conda_frontend=conda_frontend,
         use_conda=True,
     )
-    set_workflow_persistence(workflow, create_persistence_paths(conda_prefix))
+
+    persistence = PersistenceMock(
+        conda_env_path=Path(conda_prefix).resolve() if conda_prefix else None,
+        conda_env_archive_path=os.path.join(Path(".snakemake"), "conda-archive"),
+    )
+    if hasattr(workflow, "_persistence"):
+        workflow._persistence = persistence
+    else:
+        workflow.persistence = persistence
     return workflow
 
-
-def create_workflow_v8(conda_prefix):
+def create_workflow_v8(
+        conda_prefix
+    ):
     from snakemake.api import (
         Workflow,
         ConfigSettings,
@@ -92,11 +71,7 @@ def create_workflow_v8(conda_prefix):
         WorkflowSettings,
         StorageSettings,
     )
-
-    # v9+ added logger_manager as a required param; simpler to mock the whole workflow
-    if "logger_manager" in inspect.signature(Workflow).parameters:
-        return _create_workflow_namespace(conda_prefix)
-
+    workflow_kwargs = {"logger_manager": None} if "logger_manager" in inspect.signature(Workflow).parameters else {}
     conda_frontend = get_frontend()
     workflow = Workflow(
         config_settings=ConfigSettings(),
@@ -104,21 +79,31 @@ def create_workflow_v8(conda_prefix):
         workflow_settings=WorkflowSettings(),
         storage_settings=StorageSettings(),
         deployment_settings=DeploymentSettings(
-            conda_frontend=conda_frontend,
-            conda_prefix=conda_prefix,
+            conda_frontend=conda_frontend, 
+            conda_prefix=conda_prefix
         ),
+        **workflow_kwargs,
     )
-    set_workflow_persistence(workflow, create_persistence_paths(conda_prefix))
+    persistence = PersistenceMock(
+        conda_env_path=Path(conda_prefix).resolve() if conda_prefix else None,
+        conda_env_archive_path=os.path.join(Path(".snakemake"), "conda-archive"),
+    )
+    if hasattr(workflow, "_persistence"):
+        workflow._persistence = persistence
+    else:
+        workflow.persistence = persistence
     return workflow
-
 
 def conda_environment_factory(env_file_path: Path, conda_prefix_dir_path: Path) -> Env:
     """
-    Create a snakemake environment object from a given environment file and conda prefix directory.
+    Create a snakemake environment object from a given environment file and conda prefix directory
     """
     if is_snakemake_version_8_or_above:
-        snakemake_workflow = create_workflow_v8(conda_prefix_dir_path)
+        snakemake_workflow = create_workflow_v8(
+            conda_prefix_dir_path
+        )
     else:
         snakemake_workflow = create_workflow_v7(conda_prefix_dir_path)
     env_file_path = Path(env_file_path).resolve()
-    return Env(snakemake_workflow, env_file=env_file_path)
+    env = Env(snakemake_workflow, env_file=env_file_path)
+    return env

--- a/src/snk_cli/conda.py
+++ b/src/snk_cli/conda.py
@@ -17,6 +17,7 @@ except AttributeError:
 
 snakemake_version = version.parse(snakemake_version_text)
 is_snakemake_version_8_or_above = snakemake_version >= version.parse('8')
+is_snakemake_version_9_or_above = snakemake_version >= version.parse('9')
 
 
 def create_persistence_paths(conda_prefix):
@@ -121,4 +122,3 @@ def conda_environment_factory(env_file_path: Path, conda_prefix_dir_path: Path) 
         snakemake_workflow = create_workflow_v7(conda_prefix_dir_path)
     env_file_path = Path(env_file_path).resolve()
     return Env(snakemake_workflow, env_file=env_file_path)
-

--- a/src/snk_cli/conda.py
+++ b/src/snk_cli/conda.py
@@ -1,43 +1,73 @@
 # This file contains functions to create and manage conda environments for snakemake workflows
-# it needs to work with v 7 and 8 of snakemake
-# 
+# it needs to work with v7, v8, and v9 of snakemake
 from pathlib import Path
 from packaging import version
-from dataclasses import dataclass
+from types import SimpleNamespace
+import inspect
 import os
 
 from snk_cli.utils import check_command_available
 from snakemake.deployment.conda import Env
-from snakemake.persistence import Persistence
 import snakemake
 
-snakemake_version = version.parse(snakemake.__version__)
+try:
+    snakemake_version_text = snakemake.__version__
+except AttributeError:
+    from snakemake.common import __version__ as snakemake_version_text
+
+snakemake_version = version.parse(snakemake_version_text)
 is_snakemake_version_8_or_above = snakemake_version >= version.parse('8')
 
-@dataclass
-class PersistenceMock(Persistence):
+
+def create_persistence_paths(conda_prefix):
     """
-    Mock for workflow.persistence
+    Minimal workflow.persistence replacement for Env path calculation.
     """
-    conda_env_path: Path = None
-    _metadata_path: Path = None
-    _incomplete_path: Path = None
-    shadow_path: Path = None
-    conda_env_archive_path: Path = None
-    container_img_path: Path = None
-    aux_path: Path = None
+    return SimpleNamespace(
+        conda_env_path=Path(conda_prefix).resolve() if conda_prefix else None,
+        _metadata_path=None,
+        _incomplete_path=None,
+        shadow_path=None,
+        conda_env_archive_path=os.path.join(Path(".snakemake"), "conda-archive"),
+        container_img_path=None,
+        aux_path=None,
+    )
+
+
+def _create_workflow_namespace(conda_prefix):
+    """
+    Full duck-typed workflow mock for v9+, where Workflow.__init__ requires
+    logger_manager — too complex to construct just for conda env management.
+    Provides only the attributes that snakemake.deployment.conda.Env accesses.
+    """
+    persistence = create_persistence_paths(conda_prefix)
+    return SimpleNamespace(
+        persistence=persistence,
+        deployment_settings=SimpleNamespace(apptainer_args=""),
+        runtime_paths=[persistence.conda_env_path] if persistence.conda_env_path else [],
+        sourcecache=SimpleNamespace(
+            exists=lambda *a, **kw: False,
+            open=lambda *a, **kw: None,
+        ),
+    )
+
+
+def set_workflow_persistence(workflow, persistence):
+    if hasattr(workflow, "_persistence"):
+        workflow._persistence = persistence
+    else:
+        workflow.persistence = persistence
 
 
 def get_frontend():
     if check_command_available("mamba"):
-        conda_frontend = "mamba"
-    else:
-        conda_frontend = "conda"
-    return conda_frontend
+        return "mamba"
+    return "conda"
+
 
 def create_workflow_v7(conda_prefix):
     from snakemake.workflow import Workflow
-    
+
     conda_frontend = get_frontend()
     workflow = Workflow(
         snakefile=Path(),
@@ -48,20 +78,11 @@ def create_workflow_v7(conda_prefix):
         conda_frontend=conda_frontend,
         use_conda=True,
     )
-
-    persistence = PersistenceMock(
-        conda_env_path=Path(conda_prefix).resolve() if conda_prefix else None,
-        conda_env_archive_path=os.path.join(Path(".snakemake"), "conda-archive"),
-    )
-    if hasattr(workflow, "_persistence"):
-        workflow._persistence = persistence
-    else:
-        workflow.persistence = persistence
+    set_workflow_persistence(workflow, create_persistence_paths(conda_prefix))
     return workflow
 
-def create_workflow_v8(
-        conda_prefix
-    ):
+
+def create_workflow_v8(conda_prefix):
     from snakemake.api import (
         Workflow,
         ConfigSettings,
@@ -70,6 +91,11 @@ def create_workflow_v8(
         WorkflowSettings,
         StorageSettings,
     )
+
+    # v9+ added logger_manager as a required param; simpler to mock the whole workflow
+    if "logger_manager" in inspect.signature(Workflow).parameters:
+        return _create_workflow_namespace(conda_prefix)
+
     conda_frontend = get_frontend()
     workflow = Workflow(
         config_settings=ConfigSettings(),
@@ -77,30 +103,22 @@ def create_workflow_v8(
         workflow_settings=WorkflowSettings(),
         storage_settings=StorageSettings(),
         deployment_settings=DeploymentSettings(
-            conda_frontend=conda_frontend, 
-            conda_prefix=conda_prefix
+            conda_frontend=conda_frontend,
+            conda_prefix=conda_prefix,
         ),
     )
-    persistence = PersistenceMock(
-        conda_env_path=Path(conda_prefix).resolve() if conda_prefix else None,
-        conda_env_archive_path=os.path.join(Path(".snakemake"), "conda-archive"),
-    )
-    if hasattr(workflow, "_persistence"):
-        workflow._persistence = persistence
-    else:
-        workflow.persistence = persistence
+    set_workflow_persistence(workflow, create_persistence_paths(conda_prefix))
     return workflow
+
 
 def conda_environment_factory(env_file_path: Path, conda_prefix_dir_path: Path) -> Env:
     """
-    Create a snakemake environment object from a given environment file and conda prefix directory
+    Create a snakemake environment object from a given environment file and conda prefix directory.
     """
     if is_snakemake_version_8_or_above:
-        snakemake_workflow = create_workflow_v8(
-            conda_prefix_dir_path
-        )
+        snakemake_workflow = create_workflow_v8(conda_prefix_dir_path)
     else:
         snakemake_workflow = create_workflow_v7(conda_prefix_dir_path)
     env_file_path = Path(env_file_path).resolve()
-    env = Env(snakemake_workflow, env_file=env_file_path)
-    return env
+    return Env(snakemake_workflow, env_file=env_file_path)
+

--- a/src/snk_cli/dynamic_typer.py
+++ b/src/snk_cli/dynamic_typer.py
@@ -1,6 +1,5 @@
 import typer
-from click import Tuple
-from typing import List, Callable, get_origin
+from typing import List, Callable, get_args, get_origin
 from inspect import signature, Parameter
 from makefun import with_signature
 from enum import Enum
@@ -159,10 +158,7 @@ class DynamicTyper:
             annotation_type = Enum(f'{option.name}', {str(e): annotation_type(e) for e in option.choices})
         click_type = None
         if get_origin(annotation_type) is dict or annotation_type is dict:
-            click_type = Tuple([str, str])
-            if hasattr(annotation_type, '__args__') and len(annotation_type.__args__) == 2:
-                click_type = Tuple([str, annotation_type.__args__[1]])
-            annotation_type = List[Tuple]
+            annotation_type, click_type = self._get_dict_cli_types(annotation_type)
             if type(default) is dict:
                 default = [[k, v] for k, v in default.items()]
         return Parameter(
@@ -178,6 +174,20 @@ class DynamicTyper:
             ),
             annotation=annotation_type,
         )
+
+    @staticmethod
+    def _get_dict_cli_types(dict_type):
+        """
+        Return the annotation and parser type for a repeatable key-value option.
+
+        Typer uses the outer List to make an option repeatable, but does not
+        support parameterized tuples inside a List. The unparameterized tuple
+        accurately describes each parsed value, while click_type supplies the
+        concrete key and value parsers.
+        """
+        type_args = get_args(dict_type)
+        value_type = type_args[1] if len(type_args) == 2 else str
+        return List[tuple], (str, value_type)
 
     def check_if_option_passed_via_command_line(self, option: Option):
         """

--- a/src/snk_cli/subcommands/env.py
+++ b/src/snk_cli/subcommands/env.py
@@ -12,6 +12,10 @@ from ..workflow import Workflow
 from rich.console import Console
 from rich.syntax import Syntax
 from snakemake.deployment.conda import Conda, CreateCondaEnvironmentException
+try:
+    from snakemake_interface_common.exceptions import WorkflowError
+except ImportError:
+    from snakemake.exceptions import WorkflowError
 
 from concurrent.futures import ProcessPoolExecutor
 
@@ -30,7 +34,7 @@ def create_conda_environment_wrapper(args):
     env_path = Path(env_path_str).resolve()
     try:
         conda_environment_factory(env_path, conda_prefix_dir).create()
-    except CreateCondaEnvironmentException as e:
+    except (CreateCondaEnvironmentException, WorkflowError) as e:
         typer.secho(str(e), fg="red", err=True)
         return 1
     return 0
@@ -160,8 +164,13 @@ class EnvApp(DynamicTyper):
             )
             for path in env_paths 
         ]
-        with ProcessPoolExecutor(max_workers=max_workers) as executor:
-            status_codes = executor.map(create_conda_environment_wrapper, env_args)
+        if max_workers == 1:
+            status_codes = [
+                create_conda_environment_wrapper(args) for args in env_args
+            ]
+        else:
+            with ProcessPoolExecutor(max_workers=max_workers) as executor:
+                status_codes = list(executor.map(create_conda_environment_wrapper, env_args))
         if any(status_codes):
             self.error("Failed to create all conda environments!")
         if names:

--- a/src/snk_cli/subcommands/run.py
+++ b/src/snk_cli/subcommands/run.py
@@ -395,16 +395,15 @@ class RunApp(DynamicTyper):
                     )
             yield
         finally:
-            if not cleanup:
-                return
-            for copied_resource in copied_resources:
-                if copied_resource.exists():
-                    if self.verbose:
-                        self.log(
-                            f"Deleting '{copied_resource.name}' resource...",
-                            color=typer.colors.MAGENTA,
-                        )
-                    remove_resource(copied_resource)
+            if cleanup:
+                for copied_resource in copied_resources:
+                    if copied_resource.exists():
+                        if self.verbose:
+                            self.log(
+                                f"Deleting '{copied_resource.name}' resource...",
+                                color=typer.colors.MAGENTA,
+                            )
+                        remove_resource(copied_resource)
 
 def execute_snakemake(args):
     """

--- a/src/snk_cli/subcommands/run.py
+++ b/src/snk_cli/subcommands/run.py
@@ -5,7 +5,10 @@ from contextlib import contextmanager
 
 from snk_cli.dynamic_typer import DynamicTyper
 from snk_cli.options.option import Option
-from snk_cli.conda import is_snakemake_version_8_or_above
+from snk_cli.conda import (
+    is_snakemake_version_8_or_above,
+    is_snakemake_version_9_or_above,
+)
 from ..workflow import Workflow
 from snk_cli.utils import (
     parse_config_args,
@@ -219,21 +222,24 @@ class RunApp(DynamicTyper):
             )
 
         if conda_found and self.snk_config.conda and not no_conda:
-            args.extend(
-                [
-                    "--use-conda",
-                    f"--conda-prefix={self.conda_prefix_dir}",
-                ]
-            )
-            if not check_command_available("mamba"):
-                if verbose:
-                    self.log(
-                        "Could not find mamba, using conda instead...",
-                        color=typer.colors.MAGENTA,
-                    )
-                args.append("--conda-frontend=conda")
+            if is_snakemake_version_9_or_above: # support for mamba deprecated since v8.20.6(#3121)
+                args.extend(["--software-deployment-method", "conda"])
             else:
-                args.append("--conda-frontend=mamba")
+                args.extend(
+                    [
+                        "--use-conda",
+                        f"--conda-prefix={self.conda_prefix_dir}",
+                    ]
+                )
+                if not check_command_available("mamba"):
+                    if verbose:
+                        self.log(
+                            "Could not find mamba, using conda instead...",
+                            color=typer.colors.MAGENTA,
+                        )
+                    args.append("--conda-frontend=conda")
+                else:
+                    args.append("--conda-frontend=mamba")
 
         if verbose:
             args.insert(0, "--verbose")

--- a/src/snk_cli/testing.py
+++ b/src/snk_cli/testing.py
@@ -20,6 +20,7 @@ class SnkCliRunner:
     runner = CliRunner()
 
     def invoke(self, args: List[str]) -> Result:
+        args = [str(arg) for arg in args]
         old_argv = sys.argv
         sys.argv = ['cli'] + args  # ensure that the CLI is invoked with the correct arguments
         result = self.runner.invoke(self.cli.app, args)

--- a/tests/test_conda_env.py
+++ b/tests/test_conda_env.py
@@ -15,3 +15,10 @@ def test_conda_env_content(tmp_path):
     env_file = Path("tests/data/workflow/workflow/envs/wget.yml").resolve()
     env = conda_environment_factory(env_file, tmp_path)
     assert env.content == env_file.read_bytes()
+
+
+def test_conda_env_factory_creates_prefix(tmp_path):
+    env_file = Path("tests/data/workflow/workflow/envs/wget.yml").resolve()
+    conda_prefix = tmp_path / "conda"
+    conda_environment_factory(env_file, conda_prefix)
+    assert conda_prefix.exists()

--- a/tests/test_conda_env.py
+++ b/tests/test_conda_env.py
@@ -9,3 +9,9 @@ def test_conda_env(tmp_path):
     assert not Path(env.address).exists()
     env.create()
     assert Path(env.address).exists()
+
+
+def test_conda_env_content(tmp_path):
+    env_file = Path("tests/data/workflow/workflow/envs/wget.yml").resolve()
+    env = conda_environment_factory(env_file, tmp_path)
+    assert env.content == env_file.read_bytes()

--- a/tests/test_dynamic_typer.py
+++ b/tests/test_dynamic_typer.py
@@ -4,6 +4,7 @@ from snk_cli.dynamic_typer import DynamicTyper
 from snk_cli.options import Option
 from inspect import signature, Parameter
 import typer
+from typing import Dict, List
 
 class SubApp(DynamicTyper):
     def __init__(self):
@@ -92,6 +93,27 @@ def test_create_cli_parameter(dynamic_typer):
     assert param.annotation == int
     assert isinstance(param.default, typer.models.OptionInfo)
     assert param.kind == Parameter.POSITIONAL_OR_KEYWORD
+
+
+def test_create_dict_cli_parameter(dynamic_typer):
+    option = Option(
+        name="labels",
+        type=Dict[str, int],
+        required=False,
+        default={"first": 1},
+        help="Labels",
+        short=None,
+        updated=False,
+        original_key="labels",
+        flag="--labels",
+        short_flag=None,
+    )
+
+    param = dynamic_typer._create_cli_parameter(option)
+
+    assert param.annotation == List[tuple]
+    assert param.default.click_type == (str, int)
+    assert param.default.default == [["first", 1]]
 
 
 


### PR DESCRIPTION
Hi Wytamma,

I 'd like to use snk-cli with snakemake v9. so I made some small changes to make it work. it passed existing tests and I've been use it for a while with no issue.

specially this PR:

replace the previous PersistenceMock approach with a lighter duck-typed workflow/persistence mock and add logger_manager for v9+ workflow.
remove datrie in pyproject.toml as it is no longer needed since [v8.29.1](https://github.com/snakemake/snakemake/commit/f863420b948c0e33174841cf125f34aa74843ef0), and it's bundled iwth snakemake
fix dictionary CLI option handling with newer Typer versions ([vendeored click](https://typer.tiangolo.com/tutorial/click/)).
Thanks for reviewing it.